### PR TITLE
Add support to using tokens for artifactory access

### DIFF
--- a/lib/omnibus/fetchers/artifactory_fetcher.rb
+++ b/lib/omnibus/fetchers/artifactory_fetcher.rb
@@ -41,11 +41,12 @@ module Omnibus
 
       unless source.key?(:authorization)
         username = ENV['ARTIFACTORY_USERNAME'] || nil
-        password = ENV['ARTIFACTORY_PASSWORD'] || nil
+        password = ENV['ARTIFACTORY_PASSWORD'] || ENV['ARTIFACTORY_API_KEY'] || nil
         error_message = "You have to provide either source[:authorization] or environment variables for artifactory client"
         raise error_message if username.nil? || password.nil?
 
-        source[:authorization] = "Basic #{Base64.encode64("#{username}:#{password}")}"
+        # strict_encode64 is needed for error "header field value cannot include CR/LF"
+        source[:authorization] = "Basic #{Base64.strict_encode64("#{username}:#{password}")}"
       end
 
       log.debug(:debug) { "Path to file #{source[:path]} in #{source[:repository]}" }

--- a/lib/omnibus/fetchers/artifactory_fetcher.rb
+++ b/lib/omnibus/fetchers/artifactory_fetcher.rb
@@ -41,7 +41,7 @@ module Omnibus
 
       unless source.key?(:authorization)
         username = ENV['ARTIFACTORY_USERNAME'] || nil
-        password = ENV['ARTIFACTORY_PASSWORD'] || ENV['ARTIFACTORY_API_KEY'] || nil
+        password = ENV['ARTIFACTORY_PASSWORD'] || nil
         error_message = "You have to provide either source[:authorization] or environment variables for artifactory client"
         raise error_message if username.nil? || password.nil?
 


### PR DESCRIPTION
…o access Artifactory repository

when passing the username and apikey, there might be white space causing an error "header field value cannot include CR/LF" instead of Base64.encode64() use Base64.strict_encode64() function

Signed-off-by: Fries <dfries@ptc.com>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
